### PR TITLE
Add 'Shooter' Category to desktop file.

### DIFF
--- a/org.xonotic.Xonotic.desktop
+++ b/org.xonotic.Xonotic.desktop
@@ -6,4 +6,4 @@ Icon=org.xonotic.Xonotic
 Exec=xonotic-sdl
 Terminal=false
 Type=Application
-Categories=Game;ActionGame;
+Categories=Game;ActionGame;Shooter;


### PR DESCRIPTION
This game is a shooter and it will be helpful to have it tagged as such.

Categories reference: https://specifications.freedesktop.org/menu-spec/latest/apas02.html