### PR TITLE
Convert socket=x11 to x11-fallback

### DIFF
--- a/org.xonotic.Xonotic.json
+++ b/org.xonotic.Xonotic.json
@@ -7,7 +7,7 @@
         "--device=all",
         "--share=ipc",
         "--share=network",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
         /* Xonotic does not respect XDG base directories */


### PR DESCRIPTION
If Wayland is enabled, x11-fallback overrides x11