### PR TITLE
Remove Wayland support

### DIFF
--- a/org.xonotic.Xonotic.json
+++ b/org.xonotic.Xonotic.json
@@ -7,8 +7,8 @@
         "--device=all",
         "--share=ipc",
         "--share=network",
-        "--socket=fallback-x11",
-        "--socket=wayland",
+        /* Issues with Wayland, #9 */
+        "--socket=x11",
         "--socket=pulseaudio",
         /* Xonotic does not respect XDG base directories */
         "--persist=.xonotic"

--- a/org.xonotic.Xonotic.json
+++ b/org.xonotic.Xonotic.json
@@ -7,7 +7,7 @@
         "--device=all",
         "--share=ipc",
         "--share=network",
-        /* Issues with Wayland, #9 */
+        /* Text input is broken on Wayland */
         "--socket=x11",
         "--socket=pulseaudio",
         /* Xonotic does not respect XDG base directories */


### PR DESCRIPTION
Users will have to use XWayland to run the application when they're on Wayland.