### PR TITLE
Switch to Wayland by default

### DIFF
--- a/org.xonotic.Xonotic.json
+++ b/org.xonotic.Xonotic.json
@@ -7,8 +7,8 @@
         "--device=all",
         "--share=ipc",
         "--share=network",
-        /* Text input is broken on Wayland */
-        "--socket=x11",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         /* Xonotic does not respect XDG base directories */
         "--persist=.xonotic"


### PR DESCRIPTION
Using SDL 2.0.24, the text-input bug should be resolved. I had the same problem with Dhewm3. https://github.com/flathub/org.dhewm3.Dhewm3/pull/10