### PR TITLE
Build `d0_blind_id` as shared library and push key to game basedir

### DIFF
--- a/org.xonotic.Xonotic.json
+++ b/org.xonotic.Xonotic.json
@@ -53,7 +53,8 @@
                 "make all-zip-source install-data-zip-source install-engine-zip-source install-links install-doc",
                 "install -Dm644 misc/logos/xonotic_icon.svg /app/share/icons/hicolor/scalable/apps/org.xonotic.Xonotic.svg",
                 "install -Dm644 org.xonotic.Xonotic.desktop /app/share/applications/org.xonotic.Xonotic.desktop",
-                "install -Dm644 org.xonotic.Xonotic.appdata.xml /app/share/appdata/org.xonotic.Xonotic.appdata.xml"
+                "install -Dm644 org.xonotic.Xonotic.appdata.xml /app/share/appdata/org.xonotic.Xonotic.appdata.xml",
+                "install -Dm644 key_0.d0pk /app/lib/xonotic/key_0.d0pk"
             ]
         }
     ]

--- a/xonotic.patch
+++ b/xonotic.patch
@@ -81,6 +81,7 @@ index 50d829e..85fbe91 100644
 +SUFFIX ?= $(shell if [ -d .git ]; then echo git; elif [ x"$(BINARY)" = x"yes" ]; then echo zip-binary; else echo zip-source; fi)
 +RIJNDAELDETECT_CONFIGURE ?= $(shell if ! [ -f source/d0_blind_id/d0_rijndael.c ]; then echo --disable-rijndael; fi)
 +RIJNDAELDETECT_MAKE_DP ?= $(shell if [ -f source/d0_blind_id/d0_rijndael.c ]; then echo DP_CRYPTO_RIJNDAEL_STATIC_LIBDIR=$(CURDIR)/source/d0_blind_id/.libs; fi)
++export DP_LINK_CRYPTO=shared
 +
 +
 +.PHONY: all
@@ -96,13 +97,13 @@ index 50d829e..85fbe91 100644
 +
 +.PHONY: all-zip-source
 +all-zip-source:
-+	( cd source/d0_blind_id && ./configure --enable-static --disable-shared $(RIJNDAELDETECT_CONFIGURE) )
-+	$(MAKE) -C source/d0_blind_id
++	( cd source/d0_blind_id && ./configure --prefix $(PREFIX) --enable-shared --enable-static $(RIJNDAELDETECT_CONFIGURE) )
++	$(MAKE) -C source/d0_blind_id all install
 +	$(MAKE) -C source/gmqcc
 +	$(MAKE) -C source/qcsrc QCC=$(CURDIR)/source/gmqcc/gmqcc
-+	$(MAKE) -C source/darkplaces sv-release DP_CRYPTO_STATIC_LIBDIR=$(CURDIR)/source/d0_blind_id/.libs
-+	$(MAKE) -C source/darkplaces cl-release DP_CRYPTO_STATIC_LIBDIR=$(CURDIR)/source/d0_blind_id/.libs
-+	$(MAKE) -C source/darkplaces sdl-release DP_CRYPTO_STATIC_LIBDIR=$(CURDIR)/source/d0_blind_id/.libs
++	$(MAKE) -C source/darkplaces sv-release LIB_CRYPTO="-lgmp -L$(PREFIX)/lib -ld0_blind_id"
++	$(MAKE) -C source/darkplaces cl-release LIB_CRYPTO="-lgmp -L$(PREFIX)/lib -ld0_blind_id"
++	$(MAKE) -C source/darkplaces sdl-release LIB_CRYPTO="-lgmp -L$(PREFIX)/lib -ld0_blind_id"
  
 -.PHONY: clean
 -clean: clean-sources


### PR DESCRIPTION
Fixes crypto support in game and closes #4. Already tested on servers.