### PR TITLE
Set branding colours and summary to match xonotic.org, add Italian and keywords

### DIFF
--- a/xonotic2.patch
+++ b/xonotic2.patch
@@ -252,10 +252,10 @@ index 2300f38..e97e5e3 100644
 +	cp -R server $(DESTDIR)$(docdir)/
 diff --git a/misc/logos/org.xonotic.Xonotic.metainfo.xml b/misc/logos/org.xonotic.Xonotic.metainfo.xml
 new file mode 100644
-index 0000000..35fcb54
+index 0000000..90165c5
 --- /dev/null
 +++ b/misc/logos/org.xonotic.Xonotic.metainfo.xml
-@@ -0,0 +1,106 @@
+@@ -0,0 +1,133 @@
 +<?xml version="1.0" encoding="UTF-8"?>
 +<component type="desktop-application">
 +  <id>org.xonotic.Xonotic</id>
@@ -269,9 +269,16 @@ index 0000000..35fcb54
 +  <developer id="org.xonotic">
 +    <name>Team Xonotic</name>
 +  </developer>
-+  <summary>Multiplayer, deathmatch oriented first person shooter</summary>
-+  <summary xml:lang="de">Deathmatch- und Mehrspieler-orientierter Ego-Shooter</summary>
-+  <summary xml:lang="fr">Jeu de tir à la première personne multijoueur</summary>
++  <branding>
++    <color type="primary" scheme_preference="light">#04264a</color>
++    <color type="primary" scheme_preference="dark">#001021</color>
++  </branding>
++  <!-- Flathub wants summary to be 35 chars max (at least in English) -->
++  <!-- <summary> values should match the Comment= values in xonotic.desktop -->
++  <summary>The Free and Fast Arena Shooter</summary>
++  <summary xml:lang="de">Der freie und schnelle Arena-Shooter</summary>
++  <summary xml:lang="fr">Le jeu de tir Arena-shooter libre et rapide</summary>
++  <summary xml:lang="it">Lo sparatutto arena libero e veloce</summary>
 +  <description>
 +    <p>
 +      Xonotic is a free and fast-paced first person shooter which combines
@@ -286,6 +293,11 @@ index 0000000..35fcb54
 +    <p xml:lang="fr">
 +      Xonotic est un jeu de tir à la première personne gratuit, qui combine un
 +      style de jeu en arène rapide et addictif avec une large sélection d'armes.
++    </p>
++    <p xml:lang="it">
++      Xonotic è uno sparatutto arena in prima persona libero e veloce che
++      combina uno stile di gioco arena e additivo con un movimento veloce e una
++      vasta selezione di armi.
 +    </p>
 +    <p>
 +      Xonotic is easy to learn, but hard to master! Besides thrilling action for
@@ -310,6 +322,15 @@ index 0000000..35fcb54
 +      opportunités e-sport pour ceux qui sont intéressés par l'aspect
 +      compétitif.
 +    </p>
++    <p xml:lang="it">
++      Xonotic è facile da imparare ma è difficile diventare esperti! A parte
++      l'entusiasmante azione per il giocatore occasionale, il gioco regala anche
++      opportunità di e-sport per quelli che sono interessati nei suoi aspetti
++      competitivi. Da gare di creazione di mappe e tornei veloci mensili a
++      tornei sponsorizzati, Xonotic permette ad ogni appassionato di e-sport di
++      participare alle competizioni organizzate dalla sua comunità di larghe
++      vedute.
++    </p>
 +    <p>
 +      Features such as simple items, fully customizable configs and servers, a
 +      functioning anticheat system, the spectator mode, and the opportunity to
@@ -327,6 +348,12 @@ index 0000000..35fcb54
 +      anti-triche, un mode spectateur, ainsi que la possibilité d'enregistrer et
 +      visionner des démos rendent Xonotic attrayant pour les joueurs
 +      compétitifs.
++    </p>
++    <p xml:lang="it">
++      Caratteristiche come oggetti semplici, configurazioni e server interamente
++      personalizzabili, un funzionante sistema anti imbroglio, la modalità
++      spettatore, e la possibilità di guardare e registrare le partite rende
++      Xonotic attraente per i giocatori competitivi.
 +    </p>
 +  </description>
 +  <url type="bugtracker">https://gitlab.com/groups/xonotic/-/issues</url>
@@ -363,12 +390,21 @@ index 0000000..35fcb54
 +  </releases>
 +</component>
 diff --git a/misc/logos/xonotic.desktop b/misc/logos/xonotic.desktop
-index f1af0da..fbfcd22 100644
+index f1af0da..7f6da5e 100644
 --- a/misc/logos/xonotic.desktop
 +++ b/misc/logos/xonotic.desktop
-@@ -6,8 +6,33 @@ Comment=Multiplayer, deathmatch oriented first person shooter
- Comment[de]=Deathmatch- und Mehrspieler-orientierter Ego-Shooter
- Comment[fr]=Jeu de tir à la première personne multijoueur
+@@ -2,12 +2,40 @@
+ Type=Application
+ Version=1.0
+ Name=Xonotic
+-Comment=Multiplayer, deathmatch oriented first person shooter
+-Comment[de]=Deathmatch- und Mehrspieler-orientierter Ego-Shooter
+-Comment[fr]=Jeu de tir à la première personne multijoueur
++# Comment= values should match the <summary> values in org.xonotic.Xonotic.metainfo.xml
++Comment=The Free and Fast Arena Shooter
++Comment[de]=Der freie und schnelle Arena-Shooter
++Comment[fr]=Le jeu de tir Arena-shooter libre et rapide
++Comment[it]=Lo sparatutto arena libero e veloce
  Icon=xonotic
 +
 +# Note to packagers and/or .desktop file installers:
@@ -401,3 +437,4 @@ index f1af0da..fbfcd22 100644
  StartupNotify=false
 -Categories=Game;ActionGame;
 +Categories=Game;ActionGame;Shooter;
++Keywords=FPS;AFPS;arena;shooter;multiplayer;Quake;Q3;Q3A;Nexuiz;


### PR DESCRIPTION
This should fix some complaining by flathub's quality checker.

Also adds Italian and keywords.

Upstream: https://gitlab.com/xonotic/xonotic/-/merge_requests/126